### PR TITLE
Correct rotating-wave normalization and stretched-coordinate derivatives

### DIFF
--- a/@IMInternalModes/IMInternalModes.m
+++ b/@IMInternalModes/IMInternalModes.m
@@ -202,8 +202,11 @@ classdef IMInternalModes < IMEigenvalueProblem
         function spec = innerProduct(self, variable)
             % Return the signed `F` or `G` inner-product recipe.
             %
-            % For `G`, the interior weight is $$N^2/g$$. For `F`, the
-            % interior weight is one. The returned struct has fields
+            % The solved `G` variable uses the EVP's canonical weight `r`:
+            % $$N^2/g$$ for hydrostatic modes, $$(N^2-f_0^2)/g$$ at fixed
+            % wavenumber, and $$(N^2-\omega^2)/g$$ at fixed frequency.
+            % Diagnostic hydrostatic `G` uses $$N^2/g$$; `F` retains unit
+            % interior weight. The returned struct has fields
             % `variable`, `kind`, `interiorWeight`, `surfaceWeights`,
             % `bottomWeights`, `endpointInnerProductTerms`,
             % `hasInnerProduct`, and `reason`. `hasInnerProduct` is true
@@ -241,6 +244,9 @@ classdef IMInternalModes < IMEigenvalueProblem
             end
             spec.endpointInnerProductTerms = IMHydrostaticInnerProductCatalog.emptyEndpointInnerProductTerms();
             if variable == self.formulation
+                if variable == "G"
+                    spec.interiorWeight = self.r;
+                end
                 spec.surfaceWeights = self.endpointWeights("surface");
                 spec.bottomWeights = self.endpointWeights("bottom");
                 [spec.hasInnerProduct, spec.reason] = self.solvedInnerProductAvailability(spec.surfaceWeights, spec.bottomWeights);
@@ -260,12 +266,12 @@ classdef IMInternalModes < IMEigenvalueProblem
             % The signed Pontryagin product returned by `innerProduct` is
             % the physical pairing used for orthogonality and projection.
             % Its natural $$L^2\oplus\mathbb C^s$$ coordinate decomposition
-            % induces a positive Hilbert product by retaining the positive
-            % interior weight and replacing every endpoint coefficient by
-            % its absolute value:
+            % induces a positive Hilbert product by taking the absolute
+            % interior weight and the absolute value of every endpoint
+            % coefficient:
             %
             % $$
-            % (U,V)_+=\int w\,\overline{U}V\,dz+
+            % (U,V)_+=\int |w|\,\overline{U}V\,dz+
             % \sum_\ell |\alpha_\ell|\,
             % \overline{L_\ell[U]}L_\ell[V].
             % $$
@@ -273,8 +279,8 @@ classdef IMInternalModes < IMEigenvalueProblem
             % Use this recipe for magnitudes, error tolerances, and
             % convergence diagnostics. Use `innerProduct` for signed
             % invariants, projection functionals, and modal coefficients.
-            % The two recipes coincide when every endpoint coefficient is
-            % nonnegative.
+            % The two recipes coincide when the interior weight and every
+            % endpoint coefficient are nonnegative.
             %
             % - Topic: Inspect internal-mode inner products
             % - Declaration: spec = majorantInnerProduct(evp,variable)
@@ -287,6 +293,8 @@ classdef IMInternalModes < IMEigenvalueProblem
 
             spec = self.innerProduct(variable);
             spec.kind = "inducedHilbertMajorant";
+            signedWeight = spec.interiorWeight;
+            spec.interiorWeight = @(z,ctx) abs(signedWeight(z,ctx));
             for iWeight = 1:numel(spec.surfaceWeights)
                 spec.surfaceWeights(iWeight).coefficient = abs(spec.surfaceWeights(iWeight).coefficient);
             end

--- a/@IMSolverSpectral/IMSolverSpectral.m
+++ b/@IMSolverSpectral/IMSolverSpectral.m
@@ -4,7 +4,9 @@ classdef IMSolverSpectral < IMSolver
     % `IMSolverSpectral` owns the numerical coordinate choice, Chebyshev
     % resolution, derivative matrices, and physical-coordinate pullback
     % rules. It is configured against an EVP or geostrophic zero-APV problem
-    % before solving.
+    % before solving. Stretched-coordinate values, inverse maps, Jacobians,
+    % and second derivatives use one smooth Chebfun representation, so
+    % reconstruction and sampled-field calculus share the same coordinate.
     %
     % ```matlab
     % evp = IMInternalModes.waveModesAtWavenumber(N2=@(z) 1e-5*ones(size(z)), zDomain=[-1000 0], k=1e-4);
@@ -72,7 +74,7 @@ classdef IMSolverSpectral < IMSolver
     end
 
     properties (SetAccess = private)
-        % Reference physical grid for coordinate interpolation.
+        % Reference physical grid for inspecting the coordinate map.
         %
         % - Topic: Developer topics
         % - Developer: true
@@ -95,6 +97,12 @@ classdef IMSolverSpectral < IMSolver
         % - Topic: Developer topics
         % - Developer: true
         qzReference
+    end
+
+    properties (Access = private)
+        coordinateMap_ = []
+        coordinateDerivative_ = []
+        coordinateSecondDerivative_ = []
     end
 
     properties (Access = protected)
@@ -529,17 +537,39 @@ classdef IMSolverSpectral < IMSolver
             % - Declaration: x = xOfZ(solver,z)
             % - Parameter z: physical coordinate
             % - Returns x: native coordinate
-            x = interp1(self.zReference, self.xReference, z, "pchip");
+            shape = size(z);
+            z = z(:);
+            x = NaN(size(z));
+            inside = z >= self.zDomain(1) & z <= self.zDomain(2);
+            if any(inside), x(inside) = feval(self.coordinateMap_,z(inside)); end
+            x = reshape(x,shape);
         end
 
         function z = zOfX(self, x)
-            % Map native coordinate to physical coordinate.
+            % Invert the same smooth map used by physical differentiation.
             %
             % - Topic: Evaluate native modes
             % - Declaration: z = zOfX(solver,x)
             % - Parameter x: native coordinate
             % - Returns z: physical coordinate
-            z = interp1(self.xReference, self.zReference, x, "pchip");
+            shape = size(x);
+            x = x(:);
+            z = NaN(size(x));
+            inside = x >= self.xReference(1) & x <= self.xReference(end);
+            if ~any(inside), z = reshape(z,shape); return; end
+            target = x(inside);
+            lower = repmat(self.zDomain(1),size(target));
+            upper = repmat(self.zDomain(2),size(target));
+            for iteration = 1:55
+                middle = (lower+upper)/2;
+                below = feval(self.coordinateMap_,middle) < target;
+                lower(below) = middle(below);
+                upper(~below) = middle(~below);
+            end
+            z(inside) = (lower+upper)/2;
+            z(x == self.xReference(1)) = self.zDomain(1);
+            z(x == self.xReference(end)) = self.zDomain(2);
+            z = reshape(z,shape);
         end
     end
 
@@ -585,13 +615,30 @@ classdef IMSolverSpectral < IMSolver
         function self = setupCoordinate(self)
             nReference = max(2001, 20*self.nEVP);
             self.zReference = linspace(self.zDomain(1), self.zDomain(2), nReference).';
-            self.qReference = self.coordinateDerivative(self.zReference);
-            if any(self.qReference <= 0)
+            profileFunction = self.N2Function;
+            switch self.coordinateKind
+                case "z", derivativeFunction = @(z) ones(size(z));
+                case "wkb", derivativeFunction = @(z) sqrt(profileFunction(z));
+                case "density", derivativeFunction = profileFunction;
+            end
+            self.qReference = derivativeFunction(self.zReference);
+            if ~isreal(self.qReference) || any(~isfinite(self.qReference)) || any(self.qReference <= 0)
                 error("IMSolverSpectral:InvalidCoordinate", ...
                     "The native coordinate derivative dx/dz must be positive.");
             end
-            self.xReference = cumtrapz(self.zReference, self.qReference);
-            self.qzReference = gradient(self.qReference, self.zReference);
+            % Derive x, dx/dz, and d2x/dz2 from one smooth representation.
+            % Independent trapezoidal/PCHIP maps and endpoint finite
+            % differences otherwise impose a floor on second derivatives.
+            self.coordinateDerivative_ = chebfun(derivativeFunction,self.zDomain);
+            if min(self.coordinateDerivative_) <= 0
+                error("IMSolverSpectral:InvalidCoordinate","The represented coordinate derivative must remain positive throughout the domain.");
+            end
+            self.coordinateMap_ = cumsum(self.coordinateDerivative_);
+            self.coordinateMap_ = self.coordinateMap_-feval(self.coordinateMap_,self.zDomain(1));
+            self.coordinateSecondDerivative_ = diff(self.coordinateDerivative_);
+            self.xReference = feval(self.coordinateMap_,self.zReference);
+            self.qReference = feval(self.coordinateDerivative_,self.zReference);
+            self.qzReference = feval(self.coordinateSecondDerivative_,self.zReference);
         end
 
         function self = setupNativeGrid(self)
@@ -604,23 +651,12 @@ classdef IMSolverSpectral < IMSolver
             [self.T, self.Tx, self.Txx] = self.chebyshevPolynomialsAtNativePoints(self.xNative);
         end
 
-        function q = coordinateDerivative(self, z)
-            switch self.coordinateKind
-                case "z"
-                    q = ones(size(z));
-                case "wkb"
-                    q = sqrt(self.N2(z));
-                case "density"
-                    q = self.N2(z);
-            end
-        end
-
         function q = qAtZ(self, z)
-            q = self.coordinateDerivative(z);
+            q = feval(self.coordinateDerivative_,z);
         end
 
         function qz = qzAtZ(self, z)
-            qz = interp1(self.zReference, self.qzReference, z, "pchip");
+            qz = feval(self.coordinateSecondDerivative_,z);
         end
 
         function x = clampNativeCoordinate(self, x)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Version History
 
 ## Unreleased
+- made spectral stretched-coordinate maps, inverse maps, Jacobians, and second derivatives use one smooth Chebfun representation, removing the inconsistent trapezoidal/PCHIP and endpoint-gradient error floor in WKB and density coordinates
+- corrected solved G-mode normalization and projection to use the canonical EVP interior weight, including `(N2-f0^2)/g` for fixed-wavenumber waves and `(N2-omega^2)/g` for fixed-frequency waves; positive majorants now also take the absolute interior weight
 - removed the obsolete legacy fixed-frequency normalization path from production solvers, analytical helpers, examples, tests, and user documentation
 - added the induced Hilbert-majorant APIs `majorantInnerProduct`, `majorantGramMatrix`, `majorantNorm`, and `targetMajorantGramMatrix`; retained signed Pontryagin projection and spectra; and enabled coupled APV quadratic certification with retained negative modes by measuring relative errors in the positive majorant
 - moved singular-pencil rejection into generic eigenpair processing and made zero-norm classification mode-local, preventing near-null generalized eigenvectors and unrelated large columns from corrupting physical mode selection

--- a/UnitTestsV2/IMSpectralCoordinateConsistencyTests.m
+++ b/UnitTestsV2/IMSpectralCoordinateConsistencyTests.m
@@ -1,0 +1,39 @@
+classdef IMSpectralCoordinateConsistencyTests < matlab.unittest.TestCase
+    methods (Test)
+        function stretchedMapsAndDerivativesAgreeWithExactExponential(testCase)
+            D = 1000; b = 700; N0 = .01;
+            N2 = @(z)N0^2*exp(2*z/b);
+            evp = IMInternalModes.waveModesAtWavenumber(N2=N2,zDomain=[-D 0],k=1e-3,f0=1e-4);
+            for kind = ["wkb" "density"]
+                if kind == "wkb", scale = N0; rate = 1/b; else, scale = N0^2; rate = 2/b; end
+                solver = IMSolverSpectral(nEVP=65,coordinateKind=kind).configuredForEVP(evp);
+                zQuery = linspace(-D,0,111);
+                expectedX = scale/rate*(exp(rate*zQuery)-exp(-rate*D));
+                actualX = solver.xOfZ(zQuery);
+                testCase.verifyEqual(actualX,expectedX,AbsTol=5e-13)
+                testCase.verifyEqual(solver.zOfX(actualX),zQuery,AbsTol=2e-11)
+                testCase.verifyEqual(solver.qzReference,rate*scale*exp(rate*solver.zReference),RelTol=2e-11)
+                [z,~,Dz] = solver.nativeDifferentiationRule([-D 0]);
+                [~,~,Dzz] = solver.nativeDifferentiationRule([-D 0],2);
+                value = exp(rate*z);
+                testCase.verifyEqual(Dz*value,rate*value,RelTol=1e-8)
+                testCase.verifyEqual(Dzz*value,rate^2*value,RelTol=1e-7)
+                testCase.verifyTrue(all(isnan(solver.xOfZ([-D-1 1]))))
+                testCase.verifyTrue(all(isnan(solver.zOfX([-1 2*expectedX(end)]))))
+            end
+        end
+
+        function reconfigurationRebuildsMapsWithoutChangingTheOriginal(testCase)
+            firstEVP = IMInternalModes.hydrostaticGModes(N2=@(z)1e-4*exp(2*z/700),zDomain=[-1000 0]);
+            secondEVP = IMInternalModes.hydrostaticGModes(N2=@(z)4e-4*ones(size(z)),zDomain=[-1000 0]);
+            first = IMSolverSpectral(nEVP=33,coordinateKind="wkb").configuredForEVP(firstEVP);
+            z = [-1000;-500;0];
+            original = first.xOfZ(z);
+            second = first.configuredForEVP(secondEVP);
+            testCase.verifyEqual(first.xOfZ(z),original)
+            testCase.verifyEqual(second.xOfZ(z),.02*(z+1000),AbsTol=1e-12)
+            testCase.verifyEqual(second.qzReference,zeros(size(second.qzReference)),AbsTol=1e-14)
+            testCase.verifyGreaterThan(norm(first.zNative-second.zNative),1)
+        end
+    end
+end

--- a/UnitTestsV2/IMWaveInnerProductTests.m
+++ b/UnitTestsV2/IMWaveInnerProductTests.m
@@ -1,0 +1,53 @@
+classdef IMWaveInnerProductTests < matlab.unittest.TestCase
+    methods (Test)
+        function rotatingWaveNormalizationMatchesSturmLiouvilleProduct(testCase)
+            for surface = [IMBoundaryCondition.dirichlet(),IMBoundaryCondition(a=0,b=1,c=1,d=0)]
+                for slope = [0 .5]
+                    N2 = @(z)1e-4*(1+slope*z/1000);
+                    f0 = .003; g = 9.81;
+                    evp = IMInternalModes.waveModesAtWavenumber(N2=N2,zDomain=[-1000 0],k=1e-3,f0=f0,g=g,surfaceBoundary=surface);
+                    basis = IMSolverSpectral(nEVP=96,coordinateKind="wkb").solveEVP(evp,nModes=6);
+                    [z,weights] = basis.solver.nativeQuadratureRule([-1000 0]);
+                    G = basis.G(z);
+                    gram = G'*(weights.*((N2(z)-f0^2)/g).*G);
+                    if surface.c ~= 0, gram = gram+G(end,:)'*G(end,:); end
+                    testCase.verifyEqual(gram,eye(6),AbsTol=2e-8)
+                    testCase.verifyEqual(basis.gramMatrix(variable="G"),gram,AbsTol=2e-10)
+                    testCase.verifyEqual(basis.majorantGramMatrix(variable="G"),gram,AbsTol=2e-10)
+                end
+            end
+        end
+
+        function fixedFrequencyUsesItsOwnCanonicalWeight(testCase)
+            N2 = @(z)1e-4*(1+.5*z/1000);
+            omega = .003; g = 9.81;
+            evp = IMInternalModes.waveModesAtFrequency(N2=N2,zDomain=[-1000 0],omega=omega,g=g);
+            basis = IMSolverSpectral(nEVP=96,coordinateKind="wkb").solveEVP(evp,nModes=5);
+            [z,weights] = basis.solver.nativeQuadratureRule([-1000 0]);
+            G = basis.G(z);
+            gram = G'*(weights.*((N2(z)-omega^2)/g).*G);
+            testCase.verifyEqual(gram,eye(5),AbsTol=2e-8)
+        end
+
+        function analyticalRotatingModesUseTheSameCorrectedNormalization(testCase)
+            N0 = .01; f0 = .003; g = 9.81;
+            N2 = @(z)N0^2*ones(size(z));
+            evp = IMInternalModes.waveModesAtWavenumber(N2=N2,zDomain=[-1000 0],k=1e-3,f0=f0,g=g);
+            solution = IMConstantStratificationSolution(N0=N0,zDomain=[-1000 0]);
+            basis = solution.internalModes(evp,nModes=4);
+            z = linspace(-1000,0,1001).';
+            G = basis.G(z);
+            testCase.verifyEqual(trapz(z,((N0^2-f0^2)/g)*G.^2),ones(1,4),AbsTol=1e-10)
+        end
+
+        function solvedGUsesCanonicalRAndMajorantIsPositive(testCase)
+            N2 = @(z)1e-4*ones(size(z));
+            evp = IMInternalModes(N2=N2,zDomain=[-1000 0],r=@(z,~)z+500);
+            signed = evp.innerProduct("G");
+            positive = evp.majorantInnerProduct("G");
+            z = [-1000;-600;-400;0];
+            testCase.verifyEqual(signed.interiorWeight(z,struct()),z+500)
+            testCase.verifyEqual(positive.interiorWeight(z,struct()),abs(z+500))
+        end
+    end
+end

--- a/docs/classes-v2/core/iminternalmodes/geostrophicgeneralizedpotentialenstrophymodes.md
+++ b/docs/classes-v2/core/iminternalmodes/geostrophicgeneralizedpotentialenstrophymodes.md
@@ -1,0 +1,74 @@
+---
+layout: default
+title: geostrophicGeneralizedPotentialEnstrophyModes
+parent: IMInternalModes
+grand_parent: Core
+nav_order: 10
+mathjax: true
+---
+
+#  geostrophicGeneralizedPotentialEnstrophyModes
+
+Create free-surface generalized-potential-enstrophy modes.
+
+
+---
+
+## Declaration
+```matlab
+ evp = IMInternalModes.geostrophicGeneralizedPotentialEnstrophyModes(options)
+```
+## Parameters
++ `options.N2`  buoyancy frequency squared function in radians squared per second squared
++ `options.zDomain`  physical vertical domain in meters
++ `options.k`  positive horizontal wavenumber in radians per meter
++ `options.f0`  nonzero Coriolis parameter in radians per second
++ `options.g`  gravitational acceleration in meters per second squared
++ `options.alpha0`  optional positive surface generalized-potential-enstrophy weight
++ `options.alphaD`  positive bottom generalized-potential-enstrophy weight or `Inf`
+
+## Returns
++ `evp`  generalized-potential-enstrophy mode EVP
+
+## Discussion
+
+  At fixed positive horizontal wavenumber `k`, this factory
+  creates the `F` problem
+  $$
+  -\frac{\partial}{\partial z}\left(\frac{f_0^2}{N^2}\frac{\partial F_j}{\partial z}\right)
+  +k^2F_j=\Lambda_jF_j.
+  $$
+  A finite surface weight applies
+  $$
+  \frac{f_0^2}{N_s^2}F_j'(z_s)+\frac{f_0^2}{g}F_j(z_s)
+  =\Lambda_j\frac{f_0^2}{\alpha_0}F_j(z_s),
+  $$
+  while a finite bottom weight applies
+  $$
+  \frac{f_0^2}{N_b^2}F_j'(z_b)
+  =-\Lambda_j\frac{f_0^2}{\alpha_d}F_j(z_b).
+  $$
+  Positive infinity removes the corresponding eigenvalue-side
+  endpoint term. The default bottom is inactive. When `alpha0`
+  is omitted, the surface weight is
+  $$
+  \alpha_0=\frac{f_0^2}{b_\mathrm{eff}},\qquad
+  b_\mathrm{eff}=\frac{(\int N\,dz)^2}{4\int N^2\,dz}.
+  $$
+
+  Solved bases use
+  `Normalization.generalizedPotentialEnstrophy` by default, so
+  $$
+  \frac{1}{D}\left[\int F_iF_j\,dz
+  +\frac{f_0^2}{\alpha_0}F_i(z_s)F_j(z_s)
+  +\frac{f_0^2}{\alpha_d}F_i(z_b)F_j(z_b)\right]=\delta_{ij},
+  $$
+  with inactive terms omitted. The equivalent depth is the
+  diagnostic quantity
+  $$h_j=f_0^2/[g(\Lambda_j-k^2)].$$
+
+  ```matlab
+  evp = IMInternalModes.geostrophicGeneralizedPotentialEnstrophyModes( ...
+      N2=N2,zDomain=[-4000 0],k=2*pi/100e3,f0=1e-4);
+  basisSet = IMSolverSpectral(nEVP=128,coordinateKind="wkb").solveEVP(evp,nModes=8);
+  ```

--- a/docs/classes-v2/core/iminternalmodes/hfromeigenvalue.md
+++ b/docs/classes-v2/core/iminternalmodes/hfromeigenvalue.md
@@ -3,7 +3,7 @@ layout: default
 title: hFromEigenvalue
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 10
+nav_order: 11
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodes/hydrostaticfmodes.md
+++ b/docs/classes-v2/core/iminternalmodes/hydrostaticfmodes.md
@@ -3,7 +3,7 @@ layout: default
 title: hydrostaticFModes
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 11
+nav_order: 12
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodes/hydrostaticgmodes.md
+++ b/docs/classes-v2/core/iminternalmodes/hydrostaticgmodes.md
@@ -3,7 +3,7 @@ layout: default
 title: hydrostaticGModes
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 12
+nav_order: 13
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodes/index.md
+++ b/docs/classes-v2/core/iminternalmodes/index.md
@@ -46,6 +46,7 @@ G = basisSet.G(linspace(-4000,0,200).');
 + Create internal-mode EVPs
   + [`IMInternalModes`](/internal-modes/classes-v2/core/iminternalmodes/iminternalmodes.html) Create an internal-mode canonical EVP.
   + [`geostrophicAPVModes`](/internal-modes/classes-v2/core/iminternalmodes/geostrophicapvmodes.html) Create signed generalized-energy geostrophic APV modes.
+  + [`geostrophicGeneralizedPotentialEnstrophyModes`](/internal-modes/classes-v2/core/iminternalmodes/geostrophicgeneralizedpotentialenstrophymodes.html) Create free-surface generalized-potential-enstrophy modes.
   + [`hydrostaticFModes`](/internal-modes/classes-v2/core/iminternalmodes/hydrostaticfmodes.html) Create the hydrostatic `F` internal-mode EVP.
   + [`hydrostaticGModes`](/internal-modes/classes-v2/core/iminternalmodes/hydrostaticgmodes.html) Create the hydrostatic `G` internal-mode EVP.
   + [`meanDensityAnomalyModes`](/internal-modes/classes-v2/core/iminternalmodes/meandensityanomalymodes.html) Create generalized-energy mean-density-anomaly modes.

--- a/docs/classes-v2/core/iminternalmodes/innerproduct.md
+++ b/docs/classes-v2/core/iminternalmodes/innerproduct.md
@@ -3,7 +3,7 @@ layout: default
 title: innerProduct
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 13
+nav_order: 14
 mathjax: true
 ---
 
@@ -26,8 +26,11 @@ Return the signed `F` or `G` inner-product recipe.
 
 ## Discussion
 
-  For `G`, the interior weight is $$N^2/g$$. For `F`, the
-  interior weight is one. The returned struct has fields
+  The solved `G` variable uses the EVP's canonical weight `r`:
+  $$N^2/g$$ for hydrostatic modes, $$(N^2-f_0^2)/g$$ at fixed
+  wavenumber, and $$(N^2-\omega^2)/g$$ at fixed frequency.
+  Diagnostic hydrostatic `G` uses $$N^2/g$$; `F` retains unit
+  interior weight. The returned struct has fields
   `variable`, `kind`, `interiorWeight`, `surfaceWeights`,
   `bottomWeights`, `endpointInnerProductTerms`,
   `hasInnerProduct`, and `reason`. `hasInnerProduct` is true

--- a/docs/classes-v2/core/iminternalmodes/majorantinnerproduct.md
+++ b/docs/classes-v2/core/iminternalmodes/majorantinnerproduct.md
@@ -3,7 +3,7 @@ layout: default
 title: majorantInnerProduct
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 14
+nav_order: 15
 mathjax: true
 ---
 
@@ -29,12 +29,12 @@ Return the induced positive Hilbert-majorant recipe.
   The signed Pontryagin product returned by `innerProduct` is
   the physical pairing used for orthogonality and projection.
   Its natural $$L^2\oplus\mathbb C^s$$ coordinate decomposition
-  induces a positive Hilbert product by retaining the positive
-  interior weight and replacing every endpoint coefficient by
-  its absolute value:
+  induces a positive Hilbert product by taking the absolute
+  interior weight and the absolute value of every endpoint
+  coefficient:
 
   $$
-  (U,V)_+=\int w\,\overline{U}V\,dz+
+  (U,V)_+=\int |w|\,\overline{U}V\,dz+
   \sum_\ell |\alpha_\ell|\,
   \overline{L_\ell[U]}L_\ell[V].
   $$
@@ -42,5 +42,5 @@ Return the induced positive Hilbert-majorant recipe.
   Use this recipe for magnitudes, error tolerances, and
   convergence diagnostics. Use `innerProduct` for signed
   invariants, projection functionals, and modal coefficients.
-  The two recipes coincide when every endpoint coefficient is
-  nonnegative.
+  The two recipes coincide when the interior weight and every
+  endpoint coefficient are nonnegative.

--- a/docs/classes-v2/core/iminternalmodes/makebasisset.md
+++ b/docs/classes-v2/core/iminternalmodes/makebasisset.md
@@ -3,7 +3,7 @@ layout: default
 title: makeBasisSet
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 15
+nav_order: 16
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodes/meandensityanomalymodes.md
+++ b/docs/classes-v2/core/iminternalmodes/meandensityanomalymodes.md
@@ -3,7 +3,7 @@ layout: default
 title: meanDensityAnomalyModes
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 16
+nav_order: 17
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodes/modefamily.md
+++ b/docs/classes-v2/core/iminternalmodes/modefamily.md
@@ -3,7 +3,7 @@ layout: default
 title: modeFamily
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 17
+nav_order: 18
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodes/summarize.md
+++ b/docs/classes-v2/core/iminternalmodes/summarize.md
@@ -3,7 +3,7 @@ layout: default
 title: summarize
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 18
+nav_order: 19
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodes/wavemodesatfrequency.md
+++ b/docs/classes-v2/core/iminternalmodes/wavemodesatfrequency.md
@@ -3,7 +3,7 @@ layout: default
 title: waveModesAtFrequency
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 19
+nav_order: 20
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodes/wavemodesatwavenumber.md
+++ b/docs/classes-v2/core/iminternalmodes/wavemodesatwavenumber.md
@@ -3,7 +3,7 @@ layout: default
 title: waveModesAtWavenumber
 parent: IMInternalModes
 grand_parent: Core
-nav_order: 20
+nav_order: 21
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/certifieddiscretetransform.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/certifieddiscretetransform.md
@@ -40,3 +40,12 @@ Select and independently fit a certified aligned F/G family band.
   leakage and coupled quadratic policies can reduce that Gram-certified
   band; each reduction is refitted until the fitted and retained counts
   agree.
+
+  The count search fits each candidate independently but evaluates only its
+  full-band Gram matrix. For fixed candidate weights, every normalized
+  prefix error is a principal submatrix of the full-band error, so its
+  spectral norm cannot be larger. The normalized continuous target differs
+  from its diagonal signature matrix by a fixed perturbation. When the Gram
+  tolerance is smaller than the resulting nonsingularity margin, the same
+  bound proves that every prefix Gram matrix has full rank. Larger loose
+  tolerances retain a lightweight cumulative-prefix fallback.

--- a/docs/classes-v2/core/iminternalmodesbasis/discretetransform.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/discretetransform.md
@@ -35,15 +35,15 @@ Build an aligned internal-mode F/G transform through the compatibility API.
 
 ## Discussion
 
-The point rule is shared, but each requested variable retains its own
-sampled metric, active columns, target Gram matrix, and forward
-projection. Omitted `variables` selects every directly representable
-channel in canonical order `F`, `G`. Point-limited construction still
-uses roots of the next mode in the EVP's solved formulation.
+  The point rule is shared, but each requested variable retains its own
+  sampled metric, active columns, target Gram matrix, and forward
+  projection. Omitted `variables` selects every directly representable
+  channel in canonical order `F`, `G`. Point-limited construction still
+  uses roots of the next mode in the EVP's solved formulation.
 
-Supplying explicit `z` and `weights` keeps that quadrature rule unchanged.
-The method assesses every leading mode set on the one rule and returns the
-largest set that passes all enabled policies. The Gram policy must pass
-independently for every requested channel. Optional leakage uses
-same-variable rejected modes. Coupled quadratic aliasing assesses `FF->F`
-and `GG->F` when F is enabled, and `FG->G` when G is enabled.
+  Supplying explicit `z` and `weights` keeps that quadrature rule unchanged.
+  The method assesses every leading mode set on the one rule and returns the
+  largest set that passes all enabled policies. The Gram policy must pass
+  independently for every requested channel. Optional leakage uses
+  same-variable rejected modes. Coupled quadratic aliasing assesses `FF->F`
+  and `GG->F` when F is enabled, and `FG->G` when G is enabled.

--- a/docs/classes-v2/core/iminternalmodesbasis/generalizedpotentialenstrophynormfactor.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/generalizedpotentialenstrophynormfactor.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: generalizedPotentialEnstrophyNormFactor
+parent: IMInternalModesBasis
+grand_parent: Core
+nav_order: 11
+mathjax: true
+---
+
+#  generalizedPotentialEnstrophyNormFactor
+
+Return the depth-mean generalized-potential-enstrophy factor.
+
+> Developer documentation: this item describes internal implementation details.
+
+
+---
+
+## Declaration
+```matlab
+ factor = generalizedPotentialEnstrophyNormFactor(basisSet,iMode)
+```
+## Parameters
++ `iMode`  retained mode index
+
+## Returns
++ `factor`  generalized-potential-enstrophy normalization factor
+
+## Discussion
+
+  The solved `F` inner product contains the interior and active
+  endpoint terms of the generalized potential enstrophy. This
+  factor scales that complete inner product by the physical
+  depth, so normalized modes satisfy
+  $$D^{-1}\langle F_i,F_j\rangle_\alpha=\delta_{ij}.$$

--- a/docs/classes-v2/core/iminternalmodesbasis/geostrophicnormfactor.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/geostrophicnormfactor.md
@@ -3,7 +3,7 @@ layout: default
 title: geostrophicNormFactor
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 11
+nav_order: 12
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/grammatrix.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/grammatrix.md
@@ -3,7 +3,7 @@ layout: default
 title: gramMatrix
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 12
+nav_order: 13
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/h.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/h.md
@@ -3,7 +3,7 @@ layout: default
 title: h
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 13
+nav_order: 14
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/index.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/index.md
@@ -73,6 +73,7 @@ These items document internal implementation details and are not part of the pri
 + Developer topics
   + Normalization rules
     + [`depthNormFactor`](/internal-modes/classes-v2/core/iminternalmodesbasis/depthnormfactor.html) Return the volume-only depth normalization factor.
+    + [`generalizedPotentialEnstrophyNormFactor`](/internal-modes/classes-v2/core/iminternalmodesbasis/generalizedpotentialenstrophynormfactor.html) Return the depth-mean generalized-potential-enstrophy factor.
     + [`geostrophicNormFactor`](/internal-modes/classes-v2/core/iminternalmodesbasis/geostrophicnormfactor.html) Return the hydrostatic geostrophic normalization factor.
     + [`innerProductNormFactor`](/internal-modes/classes-v2/core/iminternalmodesbasis/innerproductnormfactor.html) Return the `F` or `G` inner-product norm factor.
     + [`maxAmplitudeNormFactor`](/internal-modes/classes-v2/core/iminternalmodesbasis/maxamplitudenormfactor.html) Return the maximum amplitude of `F` or `G`.

--- a/docs/classes-v2/core/iminternalmodesbasis/innerproductnormfactor.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/innerproductnormfactor.md
@@ -3,7 +3,7 @@ layout: default
 title: innerProductNormFactor
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 14
+nav_order: 15
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/majorantgrammatrix.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/majorantgrammatrix.md
@@ -3,7 +3,7 @@ layout: default
 title: majorantGramMatrix
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 15
+nav_order: 16
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/majorantinnerproduct.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/majorantinnerproduct.md
@@ -3,7 +3,7 @@ layout: default
 title: majorantInnerProduct
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 16
+nav_order: 17
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/majorantnorm.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/majorantnorm.md
@@ -3,7 +3,7 @@ layout: default
 title: majorantNorm
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 17
+nav_order: 18
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/maxamplitudenormfactor.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/maxamplitudenormfactor.md
@@ -3,7 +3,7 @@ layout: default
 title: maxAmplitudeNormFactor
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 18
+nav_order: 19
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/orientmodesigns.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/orientmodesigns.md
@@ -3,7 +3,7 @@ layout: default
 title: orientModeSigns
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 19
+nav_order: 20
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/partialwindowmodes.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/partialwindowmodes.md
@@ -3,7 +3,7 @@ layout: default
 title: partialWindowModes
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 20
+nav_order: 21
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/quadratureweightsforpoints.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/quadratureweightsforpoints.md
@@ -3,7 +3,7 @@ layout: default
 title: quadratureWeightsForPoints
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 21
+nav_order: 22
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/rawvariable.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/rawvariable.md
@@ -3,7 +3,7 @@ layout: default
 title: rawVariable
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 22
+nav_order: 23
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/spectrum.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/spectrum.md
@@ -3,7 +3,7 @@ layout: default
 title: spectrum
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 23
+nav_order: 24
 mathjax: true
 ---
 

--- a/docs/classes-v2/core/iminternalmodesbasis/surfacepressurenormfactor.md
+++ b/docs/classes-v2/core/iminternalmodesbasis/surfacepressurenormfactor.md
@@ -3,7 +3,7 @@ layout: default
 title: surfacePressureNormFactor
 parent: IMInternalModesBasis
 grand_parent: Core
-nav_order: 24
+nav_order: 25
 mathjax: true
 ---
 

--- a/docs/classes-v2/discrete-transforms/imdiscretetransformassessment/certificationsearch.md
+++ b/docs/classes-v2/discrete-transforms/imdiscretetransformassessment/certificationsearch.md
@@ -18,4 +18,6 @@ Independently refitted count-selection attempts.
 
   Empty for a direct fixed-band assessment. Certified construction
   records each attempted count and whether its freshly fitted rule
-  passed the relevant selection stage.
+  passed the relevant selection stage. Search-only Gram rows record
+  `retainedModeCount=NaN` when the full candidate was rejected,
+  because rejected candidate prefixes are intentionally not built.

--- a/docs/classes-v2/solvers/imsolver/index.md
+++ b/docs/classes-v2/solvers/imsolver/index.md
@@ -31,12 +31,13 @@ base class owns the common generalized-eigenvalue workflow.
 
 ## Topics
 + Solve EVPs
+  + [`IMSolver`](/internal-modes/classes-v2/solvers/imsolver/imsolver.html) Define the shared protocol for canonical EVP solvers.
+  + [`nativeDifferentiationRule`](/internal-modes/classes-v2/solvers/imsolver/nativedifferentiationrule.html) Return one ordered grid for physical quadrature and differentiation.
   + [`nativeQuadratureRule`](/internal-modes/classes-v2/solvers/imsolver/nativequadraturerule.html) Return the solver's native physical quadrature rule.
   + [`solveEVP`](/internal-modes/classes-v2/solvers/imsolver/solveevp.html) Solve an EVP and return a basis set.
 + Solve geostrophic zero-APV modes
   + [`solveGeostrophicZeroAPVModes`](/internal-modes/classes-v2/solvers/imsolver/solvegeostrophiczeroapvmodes.html) Solve canonical geostrophic zero-APV boundary modes.
 + Other
-  + [`IMSolver`](/internal-modes/classes-v2/solvers/imsolver/imsolver.html)
   + [`N2`](/internal-modes/classes-v2/solvers/imsolver/n2.html)
   + [`boundaryIndex`](/internal-modes/classes-v2/solvers/imsolver/boundaryindex.html)
   + [`configuredForEVP`](/internal-modes/classes-v2/solvers/imsolver/configuredforevp.html)

--- a/docs/classes-v2/solvers/imsolver/nativedifferentiationrule.md
+++ b/docs/classes-v2/solvers/imsolver/nativedifferentiationrule.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: nativeDifferentiationRule
+parent: IMSolver
+grand_parent: Solvers
+nav_order: 13
+mathjax: true
+---
+
+#  nativeDifferentiationRule
+
+Return one ordered grid for physical quadrature and differentiation.
+
+
+---
+
+## Declaration
+```matlab
+ [z,weights,Dz] = nativeDifferentiationRule(solver,zBounds,derivativeOrder)
+```
+## Parameters
++ `zBounds`  physical integration bounds
++ `derivativeOrder`  physical derivative order; default `1`
+
+## Returns
++ `z`  increasing physical grid points
++ `weights`  physical-coordinate quadrature weights
++ `Dz`  matrix mapping values on `z` to physical derivatives on `z`
+
+## Discussion
+
+  The returned points increase in physical coordinate. `weights`
+  integrate values in that order, and `Dz*values` differentiates
+  columns sampled in the same order. This keeps the grid, weights,
+  and differentiation matrix as one inseparable numerical rule.

--- a/docs/classes-v2/solvers/imsolver/nativequadraturerule.md
+++ b/docs/classes-v2/solvers/imsolver/nativequadraturerule.md
@@ -3,7 +3,7 @@ layout: default
 title: nativeQuadratureRule
 parent: IMSolver
 grand_parent: Solvers
-nav_order: 13
+nav_order: 14
 mathjax: true
 ---
 
@@ -27,8 +27,8 @@ Return the solver's native physical quadrature rule.
 
 ## Discussion
 
-The returned points are increasing in physical coordinate and
-`weights` are reordered with them. For a WKB-configured
-`IMSolverSpectral`, the points are Chebyshev--Lobatto points in
-$$x(z)=\int N(z)\,dz$$ and the weights act directly on values
-sampled in physical $$z$$.
+  The returned points are increasing in physical coordinate and
+  `weights` are reordered with them. For a WKB-configured
+  `IMSolverSpectral`, the points are Chebyshev--Lobatto points in
+  $$x(z)=\int N(z)\,dz$$ and the weights act directly on values
+  sampled in physical $$z$$.

--- a/docs/classes-v2/solvers/imsolver/physicalderivativematrix.md
+++ b/docs/classes-v2/solvers/imsolver/physicalderivativematrix.md
@@ -3,7 +3,7 @@ layout: default
 title: physicalDerivativeMatrix
 parent: IMSolver
 grand_parent: Solvers
-nav_order: 13
+nav_order: 15
 mathjax: true
 ---
 

--- a/docs/classes-v2/solvers/imsolver/rootsofnativemode.md
+++ b/docs/classes-v2/solvers/imsolver/rootsofnativemode.md
@@ -3,7 +3,7 @@ layout: default
 title: rootsOfNativeMode
 parent: IMSolver
 grand_parent: Solvers
-nav_order: 14
+nav_order: 16
 mathjax: true
 ---
 

--- a/docs/classes-v2/solvers/imsolver/solveevp.md
+++ b/docs/classes-v2/solvers/imsolver/solveevp.md
@@ -3,7 +3,7 @@ layout: default
 title: solveEVP
 parent: IMSolver
 grand_parent: Solvers
-nav_order: 15
+nav_order: 17
 mathjax: true
 ---
 

--- a/docs/classes-v2/solvers/imsolver/solvegeostrophiczeroapvmodes.md
+++ b/docs/classes-v2/solvers/imsolver/solvegeostrophiczeroapvmodes.md
@@ -3,7 +3,7 @@ layout: default
 title: solveGeostrophicZeroAPVModes
 parent: IMSolver
 grand_parent: Solvers
-nav_order: 16
+nav_order: 18
 mathjax: true
 ---
 

--- a/docs/classes-v2/solvers/imsolverspectral/index.md
+++ b/docs/classes-v2/solvers/imsolverspectral/index.md
@@ -25,7 +25,9 @@ Solve physical-coordinate EVPs with a Chebyshev spectral discretization.
 `IMSolverSpectral` owns the numerical coordinate choice, Chebyshev
 resolution, derivative matrices, and physical-coordinate pullback
 rules. It is configured against an EVP or geostrophic zero-APV problem
-before solving.
+before solving. Stretched-coordinate values, inverse maps, Jacobians,
+and second derivatives use one smooth Chebfun representation, so
+reconstruction and sampled-field calculus share the same coordinate.
 
 ```matlab
 evp = IMInternalModes.waveModesAtWavenumber(N2=@(z) 1e-5*ones(size(z)), zDomain=[-1000 0], k=1e-4);
@@ -47,7 +49,7 @@ basisSet = solver.solveEVP(evp);
   + [`zNative`](/internal-modes/classes-v2/solvers/imsolverspectral/znative.html) Physical points corresponding to `xNative`.
 + Evaluate native modes
   + [`xOfZ`](/internal-modes/classes-v2/solvers/imsolverspectral/xofz.html) Map physical coordinate to native coordinate.
-  + [`zOfX`](/internal-modes/classes-v2/solvers/imsolverspectral/zofx.html) Map native coordinate to physical coordinate.
+  + [`zOfX`](/internal-modes/classes-v2/solvers/imsolverspectral/zofx.html) Invert the same smooth map used by physical differentiation.
 
 
 ## Developer Topics
@@ -59,7 +61,7 @@ These items document internal implementation details and are not part of the pri
   + [`qReference`](/internal-modes/classes-v2/solvers/imsolverspectral/qreference.html) Reference coordinate derivative $$dx/dz$$.
   + [`qzReference`](/internal-modes/classes-v2/solvers/imsolverspectral/qzreference.html) Reference physical derivative of $$dx/dz$$.
   + [`xReference`](/internal-modes/classes-v2/solvers/imsolverspectral/xreference.html) Reference native coordinate grid.
-  + [`zReference`](/internal-modes/classes-v2/solvers/imsolverspectral/zreference.html) Reference physical grid for coordinate interpolation.
+  + [`zReference`](/internal-modes/classes-v2/solvers/imsolverspectral/zreference.html) Reference physical grid for inspecting the coordinate map.
 
 
 ---

--- a/docs/classes-v2/solvers/imsolverspectral/zofx.md
+++ b/docs/classes-v2/solvers/imsolverspectral/zofx.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  zOfX
 
-Map native coordinate to physical coordinate.
+Invert the same smooth map used by physical differentiation.
 
 
 ---

--- a/docs/classes-v2/solvers/imsolverspectral/zreference.md
+++ b/docs/classes-v2/solvers/imsolverspectral/zreference.md
@@ -9,7 +9,7 @@ mathjax: true
 
 #  zReference
 
-Reference physical grid for coordinate interpolation.
+Reference physical grid for inspecting the coordinate map.
 
 > Developer documentation: this item describes internal implementation details.
 

--- a/docs/classes-v2/supporting-types/normalization/index.md
+++ b/docs/classes-v2/supporting-types/normalization/index.md
@@ -41,6 +41,7 @@ The internal-mode values are:
 - `Normalization.surfacePressure`: scale by the raw surface value of $$F$$
 - `Normalization.geostrophic`: hydrostatic geostrophic normalization
 - `Normalization.depth`: volume-only unit depth-mean-square `F` normalization, $$s_j=\sqrt{D^{-1}\int F_j^2\,dz}$$, with the same positive factor applied to `F` and `G` and no endpoint terms
+- `Normalization.generalizedPotentialEnstrophy`: unit depth-mean generalized-potential-enstrophy normalization, including active endpoint terms
 
 ```matlab
 evp = IMInternalModes.hydrostaticGModes(N2=N2,zDomain=[-4000 0]);

--- a/docs/classes/supporting-types/normalization/index.md
+++ b/docs/classes/supporting-types/normalization/index.md
@@ -41,6 +41,7 @@ The internal-mode values are:
 - `Normalization.surfacePressure`: scale by the raw surface value of $$F$$
 - `Normalization.geostrophic`: hydrostatic geostrophic normalization
 - `Normalization.depth`: volume-only unit depth-mean-square `F` normalization, $$s_j=\sqrt{D^{-1}\int F_j^2\,dz}$$, with the same positive factor applied to `F` and `G` and no endpoint terms
+- `Normalization.generalizedPotentialEnstrophy`: unit depth-mean generalized-potential-enstrophy normalization, including active endpoint terms
 
 ```matlab
 evp = IMInternalModes.hydrostaticGModes(N2=N2,zDomain=[-4000 0]);

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -7,6 +7,8 @@ nav_order: 100
 # Version History
 
 ## Unreleased
+- made spectral stretched-coordinate maps, inverse maps, Jacobians, and second derivatives use one smooth Chebfun representation, removing the inconsistent trapezoidal/PCHIP and endpoint-gradient error floor in WKB and density coordinates
+- corrected solved G-mode normalization and projection to use the canonical EVP interior weight, including `(N2-f0^2)/g` for fixed-wavenumber waves and `(N2-omega^2)/g` for fixed-frequency waves; positive majorants now also take the absolute interior weight
 - removed the obsolete legacy fixed-frequency normalization path from production solvers, analytical helpers, examples, tests, and user documentation
 - added the induced Hilbert-majorant APIs `majorantInnerProduct`, `majorantGramMatrix`, `majorantNorm`, and `targetMajorantGramMatrix`; retained signed Pontryagin projection and spectra; and enabled coupled APV quadratic certification with retained negative modes by measuring relative errors in the positive majorant
 - moved singular-pencil rejection into generic eigenpair processing and made zero-norm classification mode-local, preventing near-null generalized eigenvectors and unrelated large columns from corrupting physical mode selection


### PR DESCRIPTION
Free-surface wave qualification for JeffreyEarly/wave-vortex-model#366 exposed two scientific defects. Rotating fixed-wavenumber G modes were normalized with `N2/g` instead of the EVP weight `(N2-f0^2)/g`, producing a relative normalization error near `1e-4` in the constant-profile control. Separately, trapezoidal/PCHIP coordinate maps and finite-difference Jacobian derivatives imposed a vertical-momentum residual around `5.62e-4` for the variable-profile long wave.

Solved G products now use canonical `r`, including the fixed-frequency weight, and the positive majorant takes its absolute value. F and diagnostic hydrostatic conventions are preserved. Spectral coordinates, their inverse, and both derivatives now derive from one smooth Chebfun representation, rebuilt on configuration. The wave consumer retains its resolved modal basis and independent sampling grid.

Validation: all 281 InternalModes V2 tests and 74 affected WVM tests passed on MATLAB R2025b Update 4; ten directly affected tests passed again after final cleanup. New tests cover rotating constant/variable rigid/free modes, fixed frequency, analytical normalization, positive majorants, exact exponential WKB/density coordinate calculus, and value-preserving reconfiguration. Modified provider source has only one pre-existing unused-input analyzer advisory. Canonical docs were regenerated, also synchronizing previously stale generated pages with existing source. Package metadata and released snapshots are unchanged.

The WVM study records constant and independently integrated variable references, all linear field equations and endpoint conditions, modal energy/projection, and separate sampling/EVP resolution sweeps. The long-wave pressure derivative retains a documented roundoff floor; increasing EVP resolution is not uniformly beneficial. This provider correction must be incorporated into the released dependency graph under JeffreyEarly/wave-vortex-model#354 before released-install qualification. This PR does not complete the full Boussinesq model in #366.
